### PR TITLE
Update osgi.jsonnet

### DIFF
--- a/otterdog/osgi.jsonnet
+++ b/otterdog/osgi.jsonnet
@@ -201,7 +201,7 @@ orgs.newOrg('technology.osgi', 'osgi') {
       workflows+: {
         allow_action_patterns+: [
           "gradle/gradle-build-action@*",
-          "gradle/wrapper-validation-action@*",
+          "gradle/actions/wrapper-validation@*",
           "peaceiris/actions-gh-pages@*"
         ],
         allow_verified_creator_actions: false,


### PR DESCRIPTION
should fix 

```
Error: Bad request - gradle/actions/wrapper-validation@v3.5.0 is not allowed to be used in osgi/osgi. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, or matching the following: gradle/gradle-build-action@*, peaceiris/actions-gh-pages@*, gradle/wrapper-validation-action@*.
```